### PR TITLE
Fix Prometheus datetime check

### DIFF
--- a/src/dremioai/api/prometheus/vm.py
+++ b/src/dremioai/api/prometheus/vm.py
@@ -139,7 +139,7 @@ async def get_promql_result(
     params = {"query": query}
     endpoint = "query_range"
     if start is not None:
-        if isinstance(str, datetime):
+        if isinstance(start, datetime):
             start = start.timestamp()
         params["start"] = start
 

--- a/tests/api/test_prometheus.py
+++ b/tests/api/test_prometheus.py
@@ -1,0 +1,33 @@
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from dremioai.api.prometheus import vm
+from dremioai.config import settings
+from dremioai.config.settings import Prometheus
+
+
+@pytest.mark.asyncio
+async def test_get_promql_result_converts_start_datetime(mock_settings_instance):
+    settings.instance().prometheus = Prometheus(uri="http://example.com", token="t")
+
+    dummy = vm.PromQLResult(status=vm.PromQLResultStatus.SUCCESS, data=vm.TimeSeriesData())
+    async_mock = AsyncMock(return_value=dummy)
+    with patch.object(vm.AsyncHttpClient, "get", async_mock) as mock_get:
+        dt = datetime(2024, 1, 1, 0, 0, 0)
+        await vm.get_promql_result("up", start=dt)
+        params = mock_get.call_args.kwargs["params"]
+        assert pytest.approx(params["start"], rel=1e-3) == dt.timestamp()
+
+@pytest.mark.asyncio
+async def test_get_promql_result_converts_end_datetime(mock_settings_instance):
+    settings.instance().prometheus = Prometheus(uri="http://example.com", token="t")
+
+    dummy = vm.PromQLResult(status=vm.PromQLResultStatus.SUCCESS, data=vm.TimeSeriesData())
+    async_mock = AsyncMock(return_value=dummy)
+    with patch.object(vm.AsyncHttpClient, "get", async_mock) as mock_get:
+        dt = datetime(2024, 1, 1, 1, 0, 0)
+        await vm.get_promql_result("up", end=dt)
+        params = mock_get.call_args.kwargs["params"]
+        assert pytest.approx(params["end"], rel=1e-3) == dt.timestamp()
+


### PR DESCRIPTION
## Summary
- fix datetime type check in `get_promql_result`
- add tests covering datetime handling for `start` and `end`

## Testing
- `uv run pytest tests/api/test_prometheus.py` *(fails: No route to host)*